### PR TITLE
Hardcode version of tensorflow to 2.15.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ setuptools
 starlette
 ta
 template
-tensorflow
+tensorflow==2.15.0
 torch
 transformers
 yfinance


### PR DESCRIPTION
Currently, the latest version of tensorflow is `2.16.0` which use `keras 3.0.5`. This is a huge breaking changes since `tensorflow 2.15.0` use `keras 2.15.0`.

This is the error log if we leave `tensorflow` in `requirements.txt` to use latest version

```
2024-03-11 16:00:27.815 |       INFO       | Miner running...              1710172827.8157468
2024-03-11 16:00:32.821 |       INFO       | Miner running...              1710172832.8213267
2024-03-11 16:00:36.901 |      TRACE       | axon     | <-- | 860 B | Challenge | xxxxxxxx | xxxxxxxxxx:48528 | 200 | Success
2024-03-11 16:00:36.901 |      TRACE       | Not Blacklisting recognized hotkey xxxxxxx
2024-03-11 16:00:36.902 |      TRACE       | Prioritizing xxxxxxxxxxxx with value: 266473.375
2024-03-11 16:00:36.905 |       INFO       | 👈 Received prediction request from: xxxxxxxxxx for timestamp: 2024-03-11T12:00:36.241385-04:00
2024-03-11 16:00:36.912 |      TRACE       | Run exception: Could not interpret initializer identifier: {'module': 'keras.initializers', 'class_name': 'Orthogonal', 'config': {'gain': 1.0, 'seed': None}, 'registered_name': None}
INFO:     23.29.118.111:48528 - "POST /Challenge HTTP/1.1" 500 Internal Server Error
2024-03-11 16:00:36.913 |      TRACE       | Forward exception: Traceback (most recent call last):
  File "/root/.sn28/lib/python3.10/site-packages/anyio/streams/memory.py", line 97, in receive
    return self.receive_nowait()
  File "/root/.sn28/lib/python3.10/site-packages/anyio/streams/memory.py", line 92, in receive_nowait
    raise WouldBlock
anyio.WouldBlock
 
During handling of the above exception, another exception occurred:
 
Traceback (most recent call last):
  File "/root/.sn28/lib/python3.10/site-packages/starlette/middleware/base.py", line 78, in call_next
    message = await recv_stream.receive()
  File "/root/.sn28/lib/python3.10/site-packages/anyio/streams/memory.py", line 112, in receive
    raise EndOfStream
anyio.EndOfStream
 
During handling of the above exception, another exception occurred:
 
Traceback (most recent call last):
  File "/root/.sn28/lib/python3.10/site-packages/bittensor/axon.py", line 1408, in run
    response = await call_next(request)
  File "/root/.sn28/lib/python3.10/site-packages/starlette/middleware/base.py", line 84, in call_next
    raise app_exc
  File "/root/.sn28/lib/python3.10/site-packages/starlette/middleware/base.py", line 70, in coro
    await self.app(scope, receive_or_disconnect, send_no_error)
  File "/root/.sn28/lib/python3.10/site-packages/starlette/middleware/exceptions.py", line 79, in __call__
    raise exc
  File "/root/.sn28/lib/python3.10/site-packages/starlette/middleware/exceptions.py", line 68, in __call__
    await self.app(scope, receive, sender)
  File "/root/.sn28/lib/python3.10/site-packages/fastapi/middleware/asyncexitstack.py", line 20, in __call__
    raise e
  File "/root/.sn28/lib/python3.10/site-packages/fastapi/middleware/asyncexitstack.py", line 17, in __call__
    await self.app(scope, receive, send)
  File "/root/.sn28/lib/python3.10/site-packages/starlette/routing.py", line 718, in __call__
    await route.handle(scope, receive, send)
  File "/root/.sn28/lib/python3.10/site-packages/starlette/routing.py", line 276, in handle
    await self.app(scope, receive, send)
  File "/root/.sn28/lib/python3.10/site-packages/starlette/routing.py", line 66, in app
    response = await func(request)
  File "/root/.sn28/lib/python3.10/site-packages/fastapi/routing.py", line 241, in app
    raw_response = await run_endpoint_function(
  File "/root/.sn28/lib/python3.10/site-packages/fastapi/routing.py", line 167, in run_endpoint_function
    return await dependant.call(**values)
  File "/root/snpOracle/./neurons/miner.py", line 169, in forward
    model = load_model(self.model_dir)
  File "/root/.sn28/lib/python3.10/site-packages/keras/src/saving/saving_api.py", line 183, in load_model
    return legacy_h5_format.load_model_from_hdf5(filepath)
  File "/root/.sn28/lib/python3.10/site-packages/keras/src/legacy/saving/legacy_h5_format.py", line 133, in load_model_from_hdf5
    model = saving_utils.model_from_config(
  File "/root/.sn28/lib/python3.10/site-packages/keras/src/legacy/saving/saving_utils.py", line 85, in model_from_config
    return serialization.deserialize_keras_object(
  File "/root/.sn28/lib/python3.10/site-packages/keras/src/legacy/saving/serialization.py", line 495, in deserialize_keras_object
    deserialized_obj = cls.from_config(
  File "/root/.sn28/lib/python3.10/site-packages/keras/src/models/sequential.py", line 327, in from_config
    layer = saving_utils.model_from_config(
  File "/root/.sn28/lib/python3.10/site-packages/keras/src/legacy/saving/saving_utils.py", line 85, in model_from_config
    return serialization.deserialize_keras_object(
  File "/root/.sn28/lib/python3.10/site-packages/keras/src/legacy/saving/serialization.py", line 504, in deserialize_keras_object
    deserialized_obj = cls.from_config(cls_config)
  File "/root/.sn28/lib/python3.10/site-packages/keras/src/layers/rnn/lstm.py", line 647, in from_config
    return cls(**config)
  File "/root/.sn28/lib/python3.10/site-packages/keras/src/layers/rnn/lstm.py", line 460, in __init__
    cell = LSTMCell(
  File "/root/.sn28/lib/python3.10/site-packages/keras/src/layers/rnn/lstm.py", line 123, in __init__
    self.recurrent_initializer = initializers.get(recurrent_initializer)
  File "/root/.sn28/lib/python3.10/site-packages/keras/src/initializers/__init__.py", line 117, in get
    raise ValueError(
ValueError: Could not interpret initializer identifier: {'module': 'keras.initializers', 'class_name': 'Orthogonal', 'config': {'gain': 1.0, 'seed': None}, 'registered_name': None}
 
During handling of the above exception, another exception occurred:
 
Traceback (most recent call last):
  File "/root/.sn28/lib/python3.10/site-packages/bittensor/axon.py", line 1068, in dispatch
    response = await self.run(synapse, call_next, request)
  File "/root/.sn28/lib/python3.10/site-packages/bittensor/axon.py", line 1422, in run
    raise RunException(f"Internal server error with error: {str(e)}")
bittensor.errors.RunException: Internal server error with error: Could not interpret initializer identifier: {'module': 'keras.initializers', 'class_name': 'Orthogonal', 'config': {'gain': 1.0, 'seed': None}, 'registered_name': None}
 
2024-03-11 16:00:36.914 |      ERROR       | RunException: Internal server error with error: Could not interpret initializer identifier: {'module': 'keras.initializers', 'class_name': 'Orthogonal', 'config': {'gain': 1.0, 'seed': None}, 'registered_name': None}
2024-03-11 16:00:36.922 |      TRACE       | axon     | --> | 216 B | Challenge | xxxxxxx | xxxxxxxx:48528  | 500 | Internal server error with error: Could not interpret initializer identifier: {'module': 'keras.initializers', 'class_name': 'Orthogonal', 'config': {'gain': 1.0, 'seed': None}, 'registered_name': None}
2024-03-11 16:00:37.822 |       INFO       | Miner running...
```